### PR TITLE
Add Streamlit front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ Dado que o usuário acessa a tela de relatórios
 Quando seleciona uma data e uma categoria  
 Então os dados exibidos devem refletir os filtros aplicados  
 Compatível com ferramentas como Cucumber, Behave, SpecFlow, etc.
+
+---
+
+## Executando com Streamlit
+
+1. Instale as dependências:
+   ```bash
+   pip install streamlit
+   ```
+2. Inicie a aplicação:
+   ```bash
+   streamlit run streamlit_app.py
+   ```
+
+Após executar, abra o navegador no endereço exibido no terminal para interagir com a interface web.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,47 @@
+import streamlit as st
+
+# Funções de placeholder para os agentes
+
+def agente_analisador_contexto(contexto: str) -> str:
+    """Simula a análise de contexto."""
+    return f"Análise de contexto para: {contexto}"
+
+
+def agente_gerador_user_stories(contexto: str, contexto_analisado: str) -> str:
+    """Simula a geração de user stories."""
+    return f"Como usuário, quero {contexto} para obter determinado benefício."
+
+
+def agente_gerador_criterios(contexto: str, contexto_analisado: str, user_stories: str) -> str:
+    """Simula a geração de critérios de aceitação."""
+    return "- O sistema deve ...\n- Deve ser possível ..."
+
+
+def agente_gerador_cenario(contexto: str, contexto_analisado: str, user_stories: str, criterios: str) -> str:
+    """Simula a geração de cenários de teste."""
+    return "Cenário: Exemplo\nDado que ...\nQuando ...\nEntão ..."
+
+
+st.title("Geração automatizada de User Stories")
+
+contexto = st.text_area("Contexto fornecido pelo Product Owner")
+executar = st.button("Executar agentes")
+
+if executar and contexto:
+    st.header("1. Análise de Contexto")
+    contexto_analisado = agente_analisador_contexto(contexto)
+    st.write(contexto_analisado)
+
+    st.header("2. User Story")
+    user_story = agente_gerador_user_stories(contexto, contexto_analisado)
+    st.write(user_story)
+
+    st.header("3. Critérios de Aceitação")
+    criterios = agente_gerador_criterios(contexto, contexto_analisado, user_story)
+    st.write(criterios)
+
+    st.header("4. Cenários de Teste (BDD)")
+    cenarios = agente_gerador_cenario(contexto, contexto_analisado, user_story, criterios)
+    st.write(cenarios)
+elif executar and not contexto:
+    st.warning("Por favor, insira um contexto antes de executar.")


### PR DESCRIPTION
## Summary
- add `streamlit_app.py` implementing a simple front-end with Streamlit
- update README with instructions on running the app

## Testing
- `pip3 show streamlit | head`
- `python3 -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_b_685050752de08333a6c062592e690a73