### PR TITLE
Create simple web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ Dado que o usuário acessa a tela de relatórios
 Quando seleciona uma data e uma categoria  
 Então os dados exibidos devem refletir os filtros aplicados  
 Compatível com ferramentas como Cucumber, Behave, SpecFlow, etc.
+
+---
+
+## 🌐 Interface Web
+
+Um exemplo simples de front-end foi adicionado em `web/` utilizando **HTML**, **TailwindCSS** e **JavaScript**. A página permite informar a chave da API do Google, descrever o contexto desejado e acionar a geração das user stories diretamente pelo navegador.
+
+Para utilizar, basta abrir o arquivo `web/index.html` em um navegador moderno, preencher os campos e clicar em **Gerar**.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Compatível com ferramentas como Cucumber, Behave, SpecFlow, etc.
 Um exemplo simples de front-end foi adicionado em `web/` utilizando **HTML**, **TailwindCSS** e **JavaScript**. A página permite informar a chave da API do Google, descrever o contexto desejado e acionar a geração das user stories diretamente pelo navegador.
 
 Para utilizar, basta abrir o arquivo `web/index.html` em um navegador moderno, preencher os campos e clicar em **Gerar**.
+
+O script utiliza a API do Gemini pela rota `https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent` e envia a chave no cabeçalho `x-goog-api-key`.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gerador de User Stories com IA</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex flex-col items-center p-4">
+    <div class="max-w-3xl w-full">
+        <h1 class="text-2xl font-bold mb-4 text-center">Gerador de User Stories</h1>
+        <div class="bg-white p-6 rounded shadow">
+            <div class="mb-4">
+                <label for="apiKey" class="block text-sm font-medium text-gray-700">Google API Key</label>
+                <input type="password" id="apiKey" class="mt-1 block w-full rounded border-gray-300" placeholder="Sua API Key">
+            </div>
+            <div class="mb-4">
+                <label for="context" class="block text-sm font-medium text-gray-700">Contexto</label>
+                <textarea id="context" rows="4" class="mt-1 block w-full rounded border-gray-300" placeholder="Descreva o contexto"></textarea>
+            </div>
+            <button id="generate" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Gerar</button>
+        </div>
+        <div id="output" class="mt-6 space-y-6"></div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,55 @@
+async function callGemini(apiKey, messages) {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+    const body = {
+        contents: messages.map(m => ({role: 'user', parts: [{text: m}]}))
+    };
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error('API error');
+    const data = await res.json();
+    return data.candidates?.[0]?.content?.parts?.map(p => p.text).join('\n') || '';
+}
+
+async function generate() {
+    const apiKey = document.getElementById('apiKey').value.trim();
+    const context = document.getElementById('context').value.trim();
+    const output = document.getElementById('output');
+
+    output.innerHTML = '';
+
+    if (!apiKey || !context) {
+        alert('Informe a API key e o contexto.');
+        return;
+    }
+
+    try {
+        const append = (title, text) => {
+            const section = document.createElement('div');
+            section.innerHTML = `<h2 class="text-xl font-semibold mb-2">${title}</h2><pre class="bg-gray-100 p-2 rounded whitespace-pre-wrap">${text}</pre>`;
+            output.appendChild(section);
+        };
+
+        const ctxAnalysisPrompt = `Você é um analista de produto. Analise o seguinte contexto e extraia persona, ação e benefício.\nContexto: ${context}`;
+        const ctxAnalysis = await callGemini(apiKey, [ctxAnalysisPrompt]);
+        append('Análise de Contexto', ctxAnalysis);
+
+        const userStoryPrompt = `Com base no contexto analisado, gere user stories no formato: Como [persona], quero [ação], para que [benefício].\nContexto Analisado: ${ctxAnalysis}`;
+        const userStories = await callGemini(apiKey, [userStoryPrompt]);
+        append('User Stories', userStories);
+
+        const criteriaPrompt = `A partir das user stories a seguir, gere critérios de aceitação claros:\nUser Stories: ${userStories}`;
+        const criteria = await callGemini(apiKey, [criteriaPrompt]);
+        append('Critérios de Aceitação', criteria);
+
+        const scenarioPrompt = `Usando os critérios de aceitação, escreva cenários de teste BDD no formato Given/When/Then.\nCritérios: ${criteria}`;
+        const scenarios = await callGemini(apiKey, [scenarioPrompt]);
+        append('Cenários de Teste', scenarios);
+    } catch (err) {
+        alert('Erro ao gerar conteúdo: ' + err.message);
+    }
+}
+
+document.getElementById('generate').addEventListener('click', generate);

--- a/web/script.js
+++ b/web/script.js
@@ -1,14 +1,28 @@
 async function callGemini(apiKey, messages) {
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+    // Use the stable v1 endpoint and send the API key via header
+    const url = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';
     const body = {
-        contents: messages.map(m => ({role: 'user', parts: [{text: m}]}))
+        contents: messages.map(m => ({ role: 'user', parts: [{ text: m }] }))
     };
+
     const res = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': apiKey
+        },
         body: JSON.stringify(body)
     });
-    if (!res.ok) throw new Error('API error');
+
+    if (!res.ok) {
+        let msg = `API error (${res.status})`;
+        try {
+            const errData = await res.json();
+            msg += `: ${errData.error?.message || JSON.stringify(errData)}`;
+        } catch { /* ignore */ }
+        throw new Error(msg);
+    }
+
     const data = await res.json();
     return data.candidates?.[0]?.content?.parts?.map(p => p.text).join('\n') || '';
 }


### PR DESCRIPTION
## Summary
- add `web/` with tailwind HTML and JavaScript
- include a field to input the API key and context
- sequentially call Gemini API to generate context analysis, user stories, criteria and test scenarios
- document how to use the web interface in the README

## Testing
- `node -e "console.log('Node working')"`

------
https://chatgpt.com/codex/tasks/task_b_685053dcf36083339285500a30adf408